### PR TITLE
Remove productive-box dependency

### DIFF
--- a/.github/workflows/pinned-gitsts.yml
+++ b/.github/workflows/pinned-gitsts.yml
@@ -5,16 +5,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 jobs:
-  productive-box:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v7
-      - name: productive-box
-        uses: maxam2017/productive-box@v1.2.0
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIST_ID: b5c387b417293ccb63e839f22f1c747c
-          TIMEZONE: Asia/Tokyo
   github-status-box:
     runs-on: ubuntu-22.04
     steps:
@@ -28,4 +18,3 @@ jobs:
           GIST_ID: f23f21fbb26f805b1c9e75497fa8434a
           ALL_COMMITS: true # If `true` it will count all commits, if `false` it will count your last year commits
           K_FORMAT: false # If `true`, large numbers will be formatted with a "k", for example "1.5k"
-


### PR DESCRIPTION
Removed the productive-box job from .github/workflows/pinned-gitsts.yml since updates for maxam2017/productive-box have stopped. Verified there are no other references.

---
*PR created automatically by Jules for task [8961452640898858885](https://jules.google.com/task/8961452640898858885) started by @9renpoto*